### PR TITLE
Adding 4.1 compatibility

### DIFF
--- a/src/Pafelin/Gearman/GearmanQueue.php
+++ b/src/Pafelin/Gearman/GearmanQueue.php
@@ -63,19 +63,19 @@ class GearmanQueue extends Queue implements QueueInterface
         return new GearmanJob($this->container, $this->worker, $queue);
     }
 
-	/**
-	 * Push a raw payload onto the queue.
-	 *
-	 * @param  string $payload
-	 * @param  string $queue
-	 * @param  array $options
-	 * @throws \Exception
-	 * @return mixed
-	 */
-	public function pushRaw($payload, $queue = null, array $options = array())
-	{
+    /**
+     * Push a raw payload onto the queue.
+     *
+     * @param  string $payload
+     * @param  string $queue
+     * @param  array $options
+     * @throws \Exception
+     * @return mixed
+     */
+    public function pushRaw($payload, $queue = null, array $options = array())
+    {
 
-		throw new Exception('Gearman driver do not support the method pushRaw');
-	}
+        throw new Exception('Gearman driver do not support the method pushRaw');
+    }
 
 }

--- a/src/Pafelin/Gearman/Jobs/GearmanJob.php
+++ b/src/Pafelin/Gearman/Jobs/GearmanJob.php
@@ -68,13 +68,13 @@ class GearmanJob extends Job {
         $this->resolveAndFire(json_decode($this->rawPayload, true));
     }
 
-	/**
-	 * Get the raw body string for the job.
-	 *
-	 * @return string
-	 */
-	public function getRawBody() {
+    /**
+     * Get the raw body string for the job.
+     *
+     * @return string
+     */
+    public function getRawBody() {
 
-		return $this->rawPayload;
-	}
+        return $this->rawPayload;
+    }
 }


### PR DESCRIPTION
Hi Pavel, I added the missing interface methods to make it syntactically work with Laravel 4.1.  since this is just adding methods that don't effectively do anything, it shouldn't be breaking anything.  I've tested locally and it seems to work just fine.
